### PR TITLE
Fix save_date default to use callable

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,7 +23,11 @@ class Event(db.Model):
     event_time = db.Column(db.String(30),nullable=False)
     user_name = db.Column(db.String(30),nullable=False)
     calender_name = db.Column(db.String(30),nullable=False)
-    save_date = db.Column(db.DateTime,nullable=False, default=datetime.now(pytz.timezone('Asia/Tokyo')))
+    save_date = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=lambda: datetime.now(pytz.timezone("Asia/Tokyo"))
+    )
 
 @app.route("/")
 def home():


### PR DESCRIPTION
## Summary
- ensure that each new Event gets the current timestamp

## Testing
- `python3 -m py_compile app.py`
- `python3 create_db.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68493420e28483228f20e1a65746e7e0